### PR TITLE
add African SMS gateways (Sendchamp, Termii, Africa's Talking, BulkSMS)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,11 +9,11 @@
 [![Downloads](https://img.shields.io/packagist/dt/mr-rijal/laravel-sms.svg)](https://packagist.org/packages/mr-rijal/laravel-sms)
 [![Star](https://img.shields.io/packagist/stars/mr-rijal/laravel-sms)](https://github.com/mr-rijal/laravel-sms)
 
-A unified, extensible SMS gateway for Laravel. Send SMS via Twilio, Vonage, MSG91, Sparrow, AWS SNS, WhatsApp, or your own driver—with one simple API.
+A unified, extensible SMS gateway for Laravel. Send SMS via Twilio, Vonage, MSG91, Sparrow, AWS SNS, WhatsApp, Sendchamp, Termii, Africa's Talking, BulkSMS, or your own driver—with one simple API.
 
 ## Features
 
-- **Multiple drivers** — Twilio, Vonage (Nexmo), MSG91, Sparrow SMS, AWS SNS, WhatsApp Business API
+- **Multiple drivers** — Twilio, Vonage (Nexmo), MSG91, Sparrow SMS, AWS SNS, WhatsApp Business API, Sendchamp, Termii, Africa's Talking, BulkSMS
 - **Laravel Notifications** — Use the `sms` channel and `SmsNotification` out of the box
 - **Queue & schedule** — `sendLater()` and `sendLaterAt()` for queued and scheduled messages
 - **Templates** — Template IDs and variables for providers that support them (e.g. MSG91, WhatsApp)
@@ -52,6 +52,27 @@ SMS_PROVIDER=twilio
 TWILIO_SID=
 TWILIO_TOKEN=
 TWILIO_FROM=
+
+# Example: Sendchamp
+SENDCHAMP_API_KEY=
+SENDCHAMP_SENDER_NAME=Sendchamp
+SENDCHAMP_ROUTE=dnd
+
+# Example: Termii
+TERMII_API_KEY=
+TERMII_SENDER_ID=
+TERMII_CHANNEL=generic
+
+# Example: Africa's Talking
+AFRICASTALKING_API_KEY=
+AFRICASTALKING_USERNAME=sandbox
+AFRICASTALKING_FROM=
+AFRICASTALKING_SANDBOX=false
+
+# Example: BulkSMS
+BULKSMS_TOKEN_ID=
+BULKSMS_TOKEN_SECRET=
+BULKSMS_FROM=
 ```
 
 ## Configuration
@@ -74,12 +95,17 @@ return [
     'queue'   => env('SMS_QUEUE', false),
 
     'drivers' => [
-        'twilio'  => \MrRijal\LaravelSms\Drivers\TwilioDriver::class,
-        'sparrow' => \MrRijal\LaravelSms\Drivers\SparrowDriver::class,
-        'msg91'   => \MrRijal\LaravelSms\Drivers\Msg91Driver::class,
-        'vonage'  => \MrRijal\LaravelSms\Drivers\VonageDriver::class,
-        'aws_sns' => \MrRijal\LaravelSms\Drivers\AwsSnsDriver::class,
-        'fake'    => \MrRijal\LaravelSms\Drivers\FakeDriver::class,
+        'twilio'         => \MrRijal\LaravelSms\Drivers\TwilioDriver::class,
+        'sparrow'        => \MrRijal\LaravelSms\Drivers\SparrowDriver::class,
+        'msg91'          => \MrRijal\LaravelSms\Drivers\Msg91Driver::class,
+        'vonage'         => \MrRijal\LaravelSms\Drivers\VonageDriver::class,
+        'aws_sns'        => \MrRijal\LaravelSms\Drivers\AwsSnsDriver::class,
+        'whatsapp'       => \MrRijal\LaravelSms\Drivers\WhatsAppDriver::class,
+        'sendchamp'      => \MrRijal\LaravelSms\Drivers\SendchampDriver::class,
+        'termii'         => \MrRijal\LaravelSms\Drivers\TermiiDriver::class,
+        'africastalking' => \MrRijal\LaravelSms\Drivers\AfricasTalkingDriver::class,
+        'bulksms'        => \MrRijal\LaravelSms\Drivers\BulkSmsDriver::class,
+        'fake'           => \MrRijal\LaravelSms\Drivers\FakeDriver::class,
     ],
 
     'providers' => [
@@ -94,6 +120,22 @@ return [
     'random_drivers' => ['twilio', 'msg91'],
 ];
 ```
+
+## Supported Drivers
+
+| Driver | Key | Region | Env Variables |
+|--------|-----|--------|---------------|
+| [Twilio](https://www.twilio.com) | `twilio` | Global | `TWILIO_SID`, `TWILIO_TOKEN`, `TWILIO_FROM` |
+| [Vonage](https://www.vonage.com) (Nexmo) | `vonage` | Global | `VONAGE_KEY`, `VONAGE_SECRET`, `VONAGE_FROM` |
+| [MSG91](https://msg91.com) | `msg91` | India | `MSG91_AUTHKEY`, `MSG91_SENDER` |
+| [Sparrow SMS](https://sparrowsms.com) | `sparrow` | Nepal | `SPARROW_TOKEN`, `SPARROW_FROM` |
+| [AWS SNS](https://aws.amazon.com/sns/) | `aws_sns` | Global | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` |
+| [WhatsApp Business](https://business.whatsapp.com) | `whatsapp` | Global | `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_ACCESS_TOKEN` |
+| [Sendchamp](https://sendchamp.com) | `sendchamp` | Nigeria / Africa | `SENDCHAMP_API_KEY`, `SENDCHAMP_SENDER_NAME`, `SENDCHAMP_ROUTE` |
+| [Termii](https://termii.com) | `termii` | Nigeria / Africa | `TERMII_API_KEY`, `TERMII_SENDER_ID`, `TERMII_CHANNEL` |
+| [Africa's Talking](https://africastalking.com) | `africastalking` | Pan-Africa | `AFRICASTALKING_API_KEY`, `AFRICASTALKING_USERNAME`, `AFRICASTALKING_FROM` |
+| [BulkSMS](https://www.bulksms.com) | `bulksms` | Africa / Global | `BULKSMS_TOKEN_ID`, `BULKSMS_TOKEN_SECRET`, `BULKSMS_FROM` |
+| Fake (testing) | `fake` | — | — |
 
 ## Usage
 

--- a/config/sms.php
+++ b/config/sms.php
@@ -154,7 +154,7 @@ return [
         ],
 
         'africastalking' => [
-            'secret' => env('AFRICASTALKING_WEBHOOK_SECRET'),
+            // Africa's Talking uses User-Agent verification, not HMAC signatures.
         ],
 
         'bulksms' => [

--- a/config/sms.php
+++ b/config/sms.php
@@ -19,6 +19,10 @@ return [
         'vonage' => Drivers\VonageDriver::class,
         'whatsapp' => Drivers\WhatsAppDriver::class,
         'aws_sns' => Drivers\AwsSnsDriver::class,
+        'sendchamp' => Drivers\SendchampDriver::class,
+        'termii' => Drivers\TermiiDriver::class,
+        'africastalking' => Drivers\AfricasTalkingDriver::class,
+        'bulksms' => Drivers\BulkSmsDriver::class,
         'fake' => Drivers\FakeDriver::class,
     ],
 
@@ -68,6 +72,31 @@ return [
             'sms_type' => env('AWS_SNS_SMS_TYPE', 'Transactional'), // Transactional or Promotional
         ],
 
+        'sendchamp' => [
+            'api_key' => env('SENDCHAMP_API_KEY'),
+            'sender_name' => env('SENDCHAMP_SENDER_NAME', 'Sendchamp'),
+            'route' => env('SENDCHAMP_ROUTE', 'dnd'), // dnd, non_dnd, or international
+        ],
+
+        'termii' => [
+            'api_key' => env('TERMII_API_KEY'),
+            'sender_id' => env('TERMII_SENDER_ID'),
+            'channel' => env('TERMII_CHANNEL', 'generic'), // generic, dnd, or whatsapp
+        ],
+
+        'africastalking' => [
+            'api_key' => env('AFRICASTALKING_API_KEY'),
+            'username' => env('AFRICASTALKING_USERNAME'),
+            'from' => env('AFRICASTALKING_FROM', ''),
+            'sandbox' => env('AFRICASTALKING_SANDBOX', false),
+        ],
+
+        'bulksms' => [
+            'token_id' => env('BULKSMS_TOKEN_ID'),
+            'token_secret' => env('BULKSMS_TOKEN_SECRET'),
+            'from' => env('BULKSMS_FROM', ''),
+        ],
+
         'fake' => [],
     ],
 
@@ -114,6 +143,22 @@ return [
 
         'sparrow' => [
             'secret' => env('SPARROW_WEBHOOK_SECRET'),
+        ],
+
+        'sendchamp' => [
+            'secret' => env('SENDCHAMP_WEBHOOK_SECRET'),
+        ],
+
+        'termii' => [
+            'secret' => env('TERMII_WEBHOOK_SECRET'),
+        ],
+
+        'africastalking' => [
+            'secret' => env('AFRICASTALKING_WEBHOOK_SECRET'),
+        ],
+
+        'bulksms' => [
+            'secret' => env('BULKSMS_WEBHOOK_SECRET'),
         ],
     ],
 ];

--- a/src/Drivers/AfricasTalkingDriver.php
+++ b/src/Drivers/AfricasTalkingDriver.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MrRijal\LaravelSms\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Events\SmsWebhookReceived;
+use MrRijal\LaravelSms\SmsMessage;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class AfricasTalkingDriver implements SmsProvider
+{
+    protected Client $client;
+
+    /**
+     * @param  array<string, mixed>  $config  api_key, username, from (optional), sandbox (optional)
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        protected array $config,
+        ?Client $client = null,
+    ) {
+        if (empty($config['api_key']) || empty($config['username'])) {
+            throw new InvalidArgumentException("Africa's Talking configuration is incomplete. Required: api_key, username");
+        }
+
+        $apiKey = (string) $config['api_key'];
+        $sandbox = ! empty($config['sandbox']);
+        $baseUri = $sandbox
+            ? 'https://api.sandbox.africastalking.com/version1/'
+            : 'https://api.africastalking.com/version1/';
+
+        $this->client = $client ?? new Client([
+            'base_uri' => $baseUri,
+            'headers' => [
+                'apiKey' => $apiKey,
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept' => 'application/json',
+            ],
+            'timeout' => 30,
+        ]);
+    }
+
+    public function send(SmsMessage $message): bool
+    {
+        $rawText = $message->getText();
+        $body = $rawText !== null ? trim($rawText) : '';
+
+        if ($body === '') {
+            throw new InvalidArgumentException("Africa's Talking SMS requires a non-empty message body.");
+        }
+
+        $username = (string) $this->config['username'];
+        $recipients = implode(',', $message->getTo());
+
+        $formParams = [
+            'username' => $username,
+            'to' => $recipients,
+            'message' => $body,
+        ];
+
+        if (! empty($this->config['from'])) {
+            $formParams['from'] = (string) $this->config['from'];
+        }
+
+        try {
+            $response = $this->client->post('messaging', [
+                'form_params' => $formParams,
+            ]);
+
+            $this->assertAfricasTalkingSuccess($response);
+        } catch (GuzzleException $e) {
+            $statusCode = 0;
+            if ($e instanceof RequestException && $e->hasResponse()) {
+                $statusCode = $e->getResponse()->getStatusCode();
+            }
+            throw new RuntimeException(
+                "Failed to send SMS via Africa's Talking: {$e->getMessage()}",
+                $statusCode,
+                $e
+            );
+        }
+
+        return true;
+    }
+
+    public function handleWebhook(Request $request): Response
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        Event::dispatch(new SmsWebhookReceived(
+            provider: 'africastalking',
+            payload: $payload,
+            messageId: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : null,
+            status: isset($payload['status']) && is_string($payload['status']) ? $payload['status'] : null,
+            recipient: isset($payload['phoneNumber']) && is_string($payload['phoneNumber']) ? $payload['phoneNumber'] : null,
+        ));
+
+        Log::info("Africa's Talking webhook received", [
+            'id' => $payload['id'] ?? null,
+            'status' => $payload['status'] ?? null,
+        ]);
+
+        return response('OK', 200);
+    }
+
+    private function assertAfricasTalkingSuccess(ResponseInterface $response): void
+    {
+        $statusCode = $response->getStatusCode();
+        $raw = $response->getBody()->getContents();
+        /** @var mixed $body */
+        $body = json_decode($raw, true);
+
+        if ($statusCode !== 201 && $statusCode !== 200) {
+            $errorMessage = is_array($body) && isset($body['SMSMessageData']['Message']) && is_string($body['SMSMessageData']['Message'])
+                ? $body['SMSMessageData']['Message']
+                : $raw;
+            throw new RuntimeException(
+                "Failed to send SMS via Africa's Talking: {$errorMessage}",
+                $statusCode
+            );
+        }
+
+        if (is_array($body) && isset($body['SMSMessageData']['Recipients'])) {
+            $recipients = $body['SMSMessageData']['Recipients'];
+            if (is_array($recipients)) {
+                foreach ($recipients as $recipient) {
+                    if (is_array($recipient) && isset($recipient['statusCode']) && (int) $recipient['statusCode'] > 399) {
+                        $msg = $recipient['status'] ?? 'Unknown error';
+                        throw new RuntimeException(
+                            "Failed to send SMS via Africa's Talking: {$msg}",
+                            (int) $recipient['statusCode']
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Drivers/AfricasTalkingDriver.php
+++ b/src/Drivers/AfricasTalkingDriver.php
@@ -96,6 +96,21 @@ class AfricasTalkingDriver implements SmsProvider
 
     public function handleWebhook(Request $request): Response
     {
+        $webhookConfig = config('sms.webhooks.africastalking', []);
+        if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
+            $signature = (string) $request->header('X-AfricasTalking-Signature', '');
+            if (! hash_equals(
+                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
+                $signature
+            )) {
+                Log::warning("Africa's Talking webhook verification failed", [
+                    'ip' => $request->ip(),
+                ]);
+
+                return response('Unauthorized', 401);
+            }
+        }
+
         /** @var array<string, mixed> $payload */
         $payload = $request->all();
 

--- a/src/Drivers/AfricasTalkingDriver.php
+++ b/src/Drivers/AfricasTalkingDriver.php
@@ -96,19 +96,14 @@ class AfricasTalkingDriver implements SmsProvider
 
     public function handleWebhook(Request $request): Response
     {
-        $webhookConfig = config('sms.webhooks.africastalking', []);
-        if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
-            $signature = (string) $request->header('X-AfricasTalking-Signature', '');
-            if (! hash_equals(
-                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
-                $signature
-            )) {
-                Log::warning("Africa's Talking webhook verification failed", [
-                    'ip' => $request->ip(),
-                ]);
+        $userAgent = (string) $request->header('User-Agent', '');
+        if (stripos($userAgent, 'AfricasTalking') === false) {
+            Log::warning("Africa's Talking webhook verification failed: invalid User-Agent", [
+                'ip' => $request->ip(),
+                'user_agent' => $userAgent,
+            ]);
 
-                return response('Unauthorized', 401);
-            }
+            return response('Unauthorized', 401);
         }
 
         /** @var array<string, mixed> $payload */

--- a/src/Drivers/BulkSmsDriver.php
+++ b/src/Drivers/BulkSmsDriver.php
@@ -58,8 +58,13 @@ class BulkSmsDriver implements SmsProvider
         }
 
         $from = isset($this->config['from']) && $this->config['from'] !== '' ? (string) $this->config['from'] : null;
+        $recipients = $message->getTo();
 
-        foreach ($message->getTo() as $to) {
+        if ($recipients === []) {
+            throw new InvalidArgumentException('BulkSMS requires at least one recipient.');
+        }
+
+        foreach ($recipients as $to) {
             $payload = [
                 'to' => $to,
                 'body' => $body,
@@ -93,6 +98,21 @@ class BulkSmsDriver implements SmsProvider
 
     public function handleWebhook(Request $request): Response
     {
+        $webhookConfig = config('sms.webhooks.bulksms', []);
+        if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
+            $signature = (string) $request->header('X-BulkSMS-Signature', '');
+            if (! hash_equals(
+                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
+                $signature
+            )) {
+                Log::warning('BulkSMS webhook verification failed', [
+                    'ip' => $request->ip(),
+                ]);
+
+                return response('Unauthorized', 401);
+            }
+        }
+
         /** @var array<string, mixed> $payload */
         $payload = $request->all();
 
@@ -100,13 +120,13 @@ class BulkSmsDriver implements SmsProvider
             provider: 'bulksms',
             payload: $payload,
             messageId: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : null,
-            status: isset($payload['status']['type']) && is_string($payload['status']['type']) ? $payload['status']['type'] : null,
+            status: is_array($payload['status'] ?? null) && isset($payload['status']['type']) && is_string($payload['status']['type']) ? $payload['status']['type'] : null,
             recipient: isset($payload['to']) && is_string($payload['to']) ? $payload['to'] : null,
         ));
 
         Log::info('BulkSMS webhook received', [
             'id' => $payload['id'] ?? null,
-            'status' => $payload['status']['type'] ?? null,
+            'status' => is_array($payload['status'] ?? null) ? ($payload['status']['type'] ?? null) : null,
         ]);
 
         return response('OK', 200);

--- a/src/Drivers/BulkSmsDriver.php
+++ b/src/Drivers/BulkSmsDriver.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MrRijal\LaravelSms\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Events\SmsWebhookReceived;
+use MrRijal\LaravelSms\SmsMessage;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class BulkSmsDriver implements SmsProvider
+{
+    protected Client $client;
+
+    /**
+     * @param  array<string, mixed>  $config  token_id, token_secret, from (optional)
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        protected array $config,
+        ?Client $client = null,
+    ) {
+        if (empty($config['token_id']) || empty($config['token_secret'])) {
+            throw new InvalidArgumentException('BulkSMS configuration is incomplete. Required: token_id, token_secret');
+        }
+
+        $tokenId = (string) $config['token_id'];
+        $tokenSecret = (string) $config['token_secret'];
+
+        $this->client = $client ?? new Client([
+            'base_uri' => 'https://api.bulksms.com/v1/',
+            'auth' => [$tokenId, $tokenSecret],
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'timeout' => 30,
+        ]);
+    }
+
+    public function send(SmsMessage $message): bool
+    {
+        $rawText = $message->getText();
+        $body = $rawText !== null ? trim($rawText) : '';
+
+        if ($body === '') {
+            throw new InvalidArgumentException('BulkSMS requires a non-empty message body.');
+        }
+
+        $from = isset($this->config['from']) && $this->config['from'] !== '' ? (string) $this->config['from'] : null;
+
+        foreach ($message->getTo() as $to) {
+            $payload = [
+                'to' => $to,
+                'body' => $body,
+            ];
+
+            if ($from !== null) {
+                $payload['from'] = $from;
+            }
+
+            try {
+                $response = $this->client->post('messages', [
+                    'json' => $payload,
+                ]);
+
+                $this->assertBulkSmsSuccess($response);
+            } catch (GuzzleException $e) {
+                $statusCode = 0;
+                if ($e instanceof RequestException && $e->hasResponse()) {
+                    $statusCode = $e->getResponse()->getStatusCode();
+                }
+                throw new RuntimeException(
+                    "Failed to send SMS via BulkSMS: {$e->getMessage()}",
+                    $statusCode,
+                    $e
+                );
+            }
+        }
+
+        return true;
+    }
+
+    public function handleWebhook(Request $request): Response
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        Event::dispatch(new SmsWebhookReceived(
+            provider: 'bulksms',
+            payload: $payload,
+            messageId: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : null,
+            status: isset($payload['status']['type']) && is_string($payload['status']['type']) ? $payload['status']['type'] : null,
+            recipient: isset($payload['to']) && is_string($payload['to']) ? $payload['to'] : null,
+        ));
+
+        Log::info('BulkSMS webhook received', [
+            'id' => $payload['id'] ?? null,
+            'status' => $payload['status']['type'] ?? null,
+        ]);
+
+        return response('OK', 200);
+    }
+
+    private function assertBulkSmsSuccess(ResponseInterface $response): void
+    {
+        $statusCode = $response->getStatusCode();
+        $raw = $response->getBody()->getContents();
+        /** @var mixed $body */
+        $body = json_decode($raw, true);
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            $errorMessage = is_array($body) && isset($body['detail']) && is_string($body['detail'])
+                ? $body['detail']
+                : $raw;
+            throw new RuntimeException(
+                "Failed to send SMS via BulkSMS: {$errorMessage}",
+                $statusCode
+            );
+        }
+    }
+}

--- a/src/Drivers/SendchampDriver.php
+++ b/src/Drivers/SendchampDriver.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MrRijal\LaravelSms\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Events\SmsWebhookReceived;
+use MrRijal\LaravelSms\SmsMessage;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class SendchampDriver implements SmsProvider
+{
+    protected Client $client;
+
+    /**
+     * @param  array<string, mixed>  $config  api_key, sender_name, route
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        protected array $config,
+        ?Client $client = null,
+    ) {
+        if (empty($config['api_key']) || empty($config['sender_name'])) {
+            throw new InvalidArgumentException('Sendchamp configuration is incomplete. Required: api_key, sender_name');
+        }
+
+        $apiKey = (string) $config['api_key'];
+
+        $this->client = $client ?? new Client([
+            'base_uri' => 'https://api.sendchamp.com/api/v1/',
+            'headers' => [
+                'Authorization' => "Bearer {$apiKey}",
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'timeout' => 30,
+        ]);
+    }
+
+    public function send(SmsMessage $message): bool
+    {
+        $rawText = $message->getText();
+        $body = $rawText !== null ? trim($rawText) : '';
+
+        if ($body === '') {
+            throw new InvalidArgumentException('Sendchamp SMS requires a non-empty message body.');
+        }
+
+        $route = (string) ($this->config['route'] ?? 'dnd');
+        $senderName = (string) $this->config['sender_name'];
+        $recipients = $message->getTo();
+
+        try {
+            $response = $this->client->post('sms/send', [
+                'json' => [
+                    'to' => array_map(fn (string $number) => ltrim($number, '+'), $recipients),
+                    'message' => $body,
+                    'sender_name' => $senderName,
+                    'route' => $route,
+                ],
+            ]);
+
+            $this->assertSendchampSuccess($response);
+        } catch (GuzzleException $e) {
+            $statusCode = 0;
+            if ($e instanceof RequestException && $e->hasResponse()) {
+                $statusCode = $e->getResponse()->getStatusCode();
+            }
+            throw new RuntimeException(
+                "Failed to send SMS via Sendchamp: {$e->getMessage()}",
+                $statusCode,
+                $e
+            );
+        }
+
+        return true;
+    }
+
+    public function handleWebhook(Request $request): Response
+    {
+        $webhookConfig = config('sms.webhooks.sendchamp', []);
+        if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
+            $signature = (string) $request->header('X-Sendchamp-Signature', '');
+            if (! hash_equals(
+                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
+                $signature
+            )) {
+                Log::warning('Sendchamp webhook verification failed', [
+                    'ip' => $request->ip(),
+                ]);
+
+                return response('Unauthorized', 401);
+            }
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        Event::dispatch(new SmsWebhookReceived(
+            provider: 'sendchamp',
+            payload: $payload,
+            messageId: isset($payload['sms_uid']) && is_string($payload['sms_uid']) ? $payload['sms_uid'] : null,
+            status: isset($payload['status']) && is_string($payload['status']) ? $payload['status'] : null,
+            recipient: isset($payload['phone_number']) && is_string($payload['phone_number']) ? $payload['phone_number'] : null,
+        ));
+
+        Log::info('Sendchamp webhook received', [
+            'sms_uid' => $payload['sms_uid'] ?? null,
+            'status' => $payload['status'] ?? null,
+        ]);
+
+        return response('OK', 200);
+    }
+
+    private function assertSendchampSuccess(ResponseInterface $response): void
+    {
+        $statusCode = $response->getStatusCode();
+        $raw = $response->getBody()->getContents();
+        /** @var mixed $body */
+        $body = json_decode($raw, true);
+
+        if ($statusCode !== 200 || (is_array($body) && ($body['status'] ?? '') === 'failed')) {
+            $errorMessage = is_array($body) && isset($body['message']) && is_string($body['message'])
+                ? $body['message']
+                : $raw;
+            throw new RuntimeException(
+                "Failed to send SMS via Sendchamp: {$errorMessage}",
+                $statusCode
+            );
+        }
+    }
+}

--- a/src/Drivers/TermiiDriver.php
+++ b/src/Drivers/TermiiDriver.php
@@ -93,7 +93,7 @@ class TermiiDriver implements SmsProvider
         if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
             $signature = (string) $request->header('X-Termii-Signature', '');
             if (! hash_equals(
-                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
+                hash_hmac('sha512', $request->getContent(), $webhookConfig['secret']),
                 $signature
             )) {
                 Log::warning('Termii webhook verification failed', [

--- a/src/Drivers/TermiiDriver.php
+++ b/src/Drivers/TermiiDriver.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MrRijal\LaravelSms\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Events\SmsWebhookReceived;
+use MrRijal\LaravelSms\SmsMessage;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class TermiiDriver implements SmsProvider
+{
+    protected Client $client;
+
+    /**
+     * @param  array<string, mixed>  $config  api_key, sender_id, channel
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        protected array $config,
+        ?Client $client = null,
+    ) {
+        if (empty($config['api_key']) || empty($config['sender_id'])) {
+            throw new InvalidArgumentException('Termii configuration is incomplete. Required: api_key, sender_id');
+        }
+
+        $this->client = $client ?? new Client([
+            'base_uri' => 'https://api.ng.termii.com/api/',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'timeout' => 30,
+        ]);
+    }
+
+    public function send(SmsMessage $message): bool
+    {
+        $rawText = $message->getText();
+        $body = $rawText !== null ? trim($rawText) : '';
+
+        if ($body === '') {
+            throw new InvalidArgumentException('Termii SMS requires a non-empty message body.');
+        }
+
+        $apiKey = (string) $this->config['api_key'];
+        $senderId = (string) $this->config['sender_id'];
+        $channel = (string) ($this->config['channel'] ?? 'generic');
+
+        foreach ($message->getTo() as $to) {
+            try {
+                $response = $this->client->post('sms/send', [
+                    'json' => [
+                        'to' => ltrim($to, '+'),
+                        'from' => $senderId,
+                        'sms' => $body,
+                        'type' => 'plain',
+                        'channel' => $channel,
+                        'api_key' => $apiKey,
+                    ],
+                ]);
+
+                $this->assertTermiiSuccess($response);
+            } catch (GuzzleException $e) {
+                $statusCode = 0;
+                if ($e instanceof RequestException && $e->hasResponse()) {
+                    $statusCode = $e->getResponse()->getStatusCode();
+                }
+                throw new RuntimeException(
+                    "Failed to send SMS via Termii: {$e->getMessage()}",
+                    $statusCode,
+                    $e
+                );
+            }
+        }
+
+        return true;
+    }
+
+    public function handleWebhook(Request $request): Response
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        Event::dispatch(new SmsWebhookReceived(
+            provider: 'termii',
+            payload: $payload,
+            messageId: isset($payload['message_id']) && is_string($payload['message_id']) ? $payload['message_id'] : null,
+            status: isset($payload['status']) && is_string($payload['status']) ? $payload['status'] : null,
+            recipient: isset($payload['to']) && is_string($payload['to']) ? $payload['to'] : null,
+        ));
+
+        Log::info('Termii webhook received', [
+            'message_id' => $payload['message_id'] ?? null,
+            'status' => $payload['status'] ?? null,
+        ]);
+
+        return response('OK', 200);
+    }
+
+    private function assertTermiiSuccess(ResponseInterface $response): void
+    {
+        $statusCode = $response->getStatusCode();
+        $raw = $response->getBody()->getContents();
+        /** @var mixed $body */
+        $body = json_decode($raw, true);
+
+        if ($statusCode !== 200 || (is_array($body) && isset($body['code']) && $body['code'] !== 'ok')) {
+            $errorMessage = is_array($body) && isset($body['message']) && is_string($body['message'])
+                ? $body['message']
+                : $raw;
+            throw new RuntimeException(
+                "Failed to send SMS via Termii: {$errorMessage}",
+                $statusCode
+            );
+        }
+    }
+}

--- a/src/Drivers/TermiiDriver.php
+++ b/src/Drivers/TermiiDriver.php
@@ -89,6 +89,21 @@ class TermiiDriver implements SmsProvider
 
     public function handleWebhook(Request $request): Response
     {
+        $webhookConfig = config('sms.webhooks.termii', []);
+        if (is_array($webhookConfig) && ! empty($webhookConfig['secret']) && is_string($webhookConfig['secret'])) {
+            $signature = (string) $request->header('X-Termii-Signature', '');
+            if (! hash_equals(
+                hash_hmac('sha256', $request->getContent(), $webhookConfig['secret']),
+                $signature
+            )) {
+                Log::warning('Termii webhook verification failed', [
+                    'ip' => $request->ip(),
+                ]);
+
+                return response('Unauthorized', 401);
+            }
+        }
+
         /** @var array<string, mixed> $payload */
         $payload = $request->all();
 

--- a/tests/Drivers/AfricasTalkingDriverTest.php
+++ b/tests/Drivers/AfricasTalkingDriverTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace MrRijal\LaravelSms\Tests\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Drivers\AfricasTalkingDriver;
+use MrRijal\LaravelSms\SmsMessage;
+use MrRijal\LaravelSms\Tests\TestCase;
+
+class AfricasTalkingDriverTest extends TestCase
+{
+    public function test_implements_sms_provider(): void
+    {
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'sandbox',
+        ]);
+
+        $this->assertInstanceOf(SmsProvider::class, $driver);
+    }
+
+    public function test_constructor_throws_when_api_key_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Africa's Talking configuration is incomplete");
+
+        new AfricasTalkingDriver([
+            'username' => 'sandbox',
+        ]);
+    }
+
+    public function test_constructor_throws_when_username_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Africa's Talking configuration is incomplete");
+
+        new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+        ]);
+    }
+
+    public function test_constructor_succeeds_with_valid_config(): void
+    {
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'sandbox',
+        ]);
+
+        $this->assertInstanceOf(AfricasTalkingDriver::class, $driver);
+    }
+
+    public function test_send_throws_when_no_body_text(): void
+    {
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'sandbox',
+        ]);
+        $message = (new SmsMessage)->to('+254711123456');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Africa's Talking SMS requires a non-empty message body");
+
+        $driver->send($message);
+    }
+
+    public function test_send_success_with_mock_client(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode([
+                'SMSMessageData' => [
+                    'Message' => 'Sent to 1/1 Total Cost: KES 0.8000',
+                    'Recipients' => [
+                        [
+                            'statusCode' => 101,
+                            'number' => '+254711123456',
+                            'cost' => 'KES 0.8000',
+                            'status' => 'Success',
+                            'messageId' => 'ATXid_123',
+                        ],
+                    ],
+                ],
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'sandbox',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+254711123456')->message("Hello Africa's Talking");
+        $result = $driver->send($message);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_send_uses_comma_separated_recipients(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode([
+                'SMSMessageData' => [
+                    'Message' => 'Sent to 2/2',
+                    'Recipients' => [
+                        ['statusCode' => 101, 'status' => 'Success'],
+                        ['statusCode' => 101, 'status' => 'Success'],
+                    ],
+                ],
+            ])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new Client(['handler' => $stack]);
+
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'testuser',
+        ], $client);
+
+        $message = (new SmsMessage)->to(['+254711123456', '+254722123456'])->message('Hello');
+        $driver->send($message);
+
+        $requestBody = (string) $history[0]['request']->getBody();
+        parse_str($requestBody, $parsed);
+        $this->assertStringContainsString('+254711123456', $parsed['to']);
+        $this->assertStringContainsString('+254722123456', $parsed['to']);
+        $this->assertEquals('testuser', $parsed['username']);
+    }
+
+    public function test_send_throws_on_recipient_failure(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode([
+                'SMSMessageData' => [
+                    'Message' => 'Sent to 0/1',
+                    'Recipients' => [
+                        [
+                            'statusCode' => 403,
+                            'status' => 'InsufficientBalance',
+                            'number' => '+254711123456',
+                        ],
+                    ],
+                ],
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'test-key',
+            'username' => 'sandbox',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+254711123456')->message('Test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Failed to send SMS via Africa's Talking");
+
+        $driver->send($message);
+    }
+
+    public function test_send_throws_on_http_error(): void
+    {
+        $mock = new MockHandler([
+            new Response(401, [], json_encode([
+                'SMSMessageData' => [
+                    'Message' => 'Invalid API key',
+                ],
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new AfricasTalkingDriver([
+            'api_key' => 'bad-key',
+            'username' => 'sandbox',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+254711123456')->message('Test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Failed to send SMS via Africa's Talking");
+
+        $driver->send($message);
+    }
+}

--- a/tests/Drivers/BulkSmsDriverTest.php
+++ b/tests/Drivers/BulkSmsDriverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace MrRijal\LaravelSms\Tests\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Drivers\BulkSmsDriver;
+use MrRijal\LaravelSms\SmsMessage;
+use MrRijal\LaravelSms\Tests\TestCase;
+
+class BulkSmsDriverTest extends TestCase
+{
+    public function test_implements_sms_provider(): void
+    {
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+        ]);
+
+        $this->assertInstanceOf(SmsProvider::class, $driver);
+    }
+
+    public function test_constructor_throws_when_token_id_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BulkSMS configuration is incomplete');
+
+        new BulkSmsDriver([
+            'token_secret' => 'test-secret',
+        ]);
+    }
+
+    public function test_constructor_throws_when_token_secret_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BulkSMS configuration is incomplete');
+
+        new BulkSmsDriver([
+            'token_id' => 'test-id',
+        ]);
+    }
+
+    public function test_constructor_succeeds_with_valid_config(): void
+    {
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+        ]);
+
+        $this->assertInstanceOf(BulkSmsDriver::class, $driver);
+    }
+
+    public function test_send_throws_when_no_body_text(): void
+    {
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+        ]);
+        $message = (new SmsMessage)->to('+2348134844186');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BulkSMS requires a non-empty message body');
+
+        $driver->send($message);
+    }
+
+    public function test_send_success_with_mock_client(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode([
+                'id' => '12345',
+                'type' => 'SENT',
+                'to' => '+2348134844186',
+                'body' => 'Hello BulkSMS',
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello BulkSMS');
+        $result = $driver->send($message);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_send_includes_from_when_configured(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode(['id' => '123'])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new Client(['handler' => $stack]);
+
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+            'from' => 'MyBrand',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello');
+        $driver->send($message);
+
+        $requestBody = json_decode((string) $history[0]['request']->getBody(), true);
+        $this->assertEquals('MyBrand', $requestBody['from']);
+    }
+
+    public function test_send_omits_from_when_not_configured(): void
+    {
+        $mock = new MockHandler([
+            new Response(201, [], json_encode(['id' => '123'])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new Client(['handler' => $stack]);
+
+        $driver = new BulkSmsDriver([
+            'token_id' => 'test-id',
+            'token_secret' => 'test-secret',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello');
+        $driver->send($message);
+
+        $requestBody = json_decode((string) $history[0]['request']->getBody(), true);
+        $this->assertArrayNotHasKey('from', $requestBody);
+    }
+
+    public function test_send_throws_on_failed_response(): void
+    {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode([
+                'detail' => 'Invalid credentials',
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new BulkSmsDriver([
+            'token_id' => 'bad-id',
+            'token_secret' => 'bad-secret',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send SMS via BulkSMS');
+
+        $driver->send($message);
+    }
+}

--- a/tests/Drivers/SendchampDriverTest.php
+++ b/tests/Drivers/SendchampDriverTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace MrRijal\LaravelSms\Tests\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Drivers\SendchampDriver;
+use MrRijal\LaravelSms\SmsMessage;
+use MrRijal\LaravelSms\Tests\TestCase;
+
+class SendchampDriverTest extends TestCase
+{
+    public function test_implements_sms_provider(): void
+    {
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+        ]);
+
+        $this->assertInstanceOf(SmsProvider::class, $driver);
+    }
+
+    public function test_constructor_throws_when_api_key_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sendchamp configuration is incomplete');
+
+        new SendchampDriver([
+            'sender_name' => 'TestSender',
+        ]);
+    }
+
+    public function test_constructor_throws_when_sender_name_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sendchamp configuration is incomplete');
+
+        new SendchampDriver([
+            'api_key' => 'test-key',
+        ]);
+    }
+
+    public function test_constructor_succeeds_with_valid_config(): void
+    {
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+        ]);
+
+        $this->assertInstanceOf(SendchampDriver::class, $driver);
+    }
+
+    public function test_send_throws_when_no_body_text(): void
+    {
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+        ]);
+        $message = (new SmsMessage)->to('+2348134844186');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sendchamp SMS requires a non-empty message body');
+
+        $driver->send($message);
+    }
+
+    public function test_send_success_with_mock_client(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'code' => 200,
+                'data' => [
+                    'id' => 'MN-SMS-ad51fcd1-8257-4fc5-b6df-11cf2ddcdfac',
+                    'phone_number' => '2348134844186',
+                    'reference' => 'MN-SMS-ad51fcd1-8257-4fc5-b6df-11cf2ddcdfac',
+                    'status' => 'processing',
+                ],
+                'errors' => null,
+                'message' => 'processing',
+                'status' => 'success',
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+            'route' => 'dnd',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello Sendchamp');
+        $result = $driver->send($message);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_send_throws_on_failed_response(): void
+    {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode([
+                'code' => 400,
+                'data' => null,
+                'errors' => 'Message required',
+                'message' => 'Message required',
+                'status' => 'failed',
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send SMS via Sendchamp');
+
+        $driver->send($message);
+    }
+
+    public function test_send_uses_default_dnd_route(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'code' => 200,
+                'status' => 'success',
+                'message' => 'processing',
+                'data' => ['id' => 'test', 'status' => 'processing'],
+            ])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new Client(['handler' => $stack]);
+
+        $driver = new SendchampDriver([
+            'api_key' => 'test-key',
+            'sender_name' => 'TestSender',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello');
+        $driver->send($message);
+
+        $requestBody = json_decode((string) $history[0]['request']->getBody(), true);
+        $this->assertEquals('dnd', $requestBody['route']);
+    }
+}

--- a/tests/Drivers/TermiiDriverTest.php
+++ b/tests/Drivers/TermiiDriverTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace MrRijal\LaravelSms\Tests\Drivers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use MrRijal\LaravelSms\Contracts\SmsProvider;
+use MrRijal\LaravelSms\Drivers\TermiiDriver;
+use MrRijal\LaravelSms\SmsMessage;
+use MrRijal\LaravelSms\Tests\TestCase;
+
+class TermiiDriverTest extends TestCase
+{
+    public function test_implements_sms_provider(): void
+    {
+        $driver = new TermiiDriver([
+            'api_key' => 'test-key',
+            'sender_id' => 'TestSender',
+        ]);
+
+        $this->assertInstanceOf(SmsProvider::class, $driver);
+    }
+
+    public function test_constructor_throws_when_api_key_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Termii configuration is incomplete');
+
+        new TermiiDriver([
+            'sender_id' => 'TestSender',
+        ]);
+    }
+
+    public function test_constructor_throws_when_sender_id_missing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Termii configuration is incomplete');
+
+        new TermiiDriver([
+            'api_key' => 'test-key',
+        ]);
+    }
+
+    public function test_constructor_succeeds_with_valid_config(): void
+    {
+        $driver = new TermiiDriver([
+            'api_key' => 'test-key',
+            'sender_id' => 'TestSender',
+        ]);
+
+        $this->assertInstanceOf(TermiiDriver::class, $driver);
+    }
+
+    public function test_send_throws_when_no_body_text(): void
+    {
+        $driver = new TermiiDriver([
+            'api_key' => 'test-key',
+            'sender_id' => 'TestSender',
+        ]);
+        $message = (new SmsMessage)->to('+2348134844186');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Termii SMS requires a non-empty message body');
+
+        $driver->send($message);
+    }
+
+    public function test_send_success_with_mock_client(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'code' => 'ok',
+                'message_id' => 'msg-123',
+                'message' => 'Successfully Sent',
+                'balance' => 100,
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new TermiiDriver([
+            'api_key' => 'test-key',
+            'sender_id' => 'TestSender',
+            'channel' => 'generic',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello Termii');
+        $result = $driver->send($message);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_send_includes_api_key_in_payload(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'code' => 'ok',
+                'message' => 'Successfully Sent',
+            ])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new Client(['handler' => $stack]);
+
+        $driver = new TermiiDriver([
+            'api_key' => 'my-secret-key',
+            'sender_id' => 'TestSender',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Hello');
+        $driver->send($message);
+
+        $requestBody = json_decode((string) $history[0]['request']->getBody(), true);
+        $this->assertEquals('my-secret-key', $requestBody['api_key']);
+        $this->assertEquals('TestSender', $requestBody['from']);
+        $this->assertEquals('generic', $requestBody['channel']);
+        $this->assertEquals('plain', $requestBody['type']);
+    }
+
+    public function test_send_throws_on_failed_response(): void
+    {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode([
+                'message' => 'Invalid API key',
+            ])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $driver = new TermiiDriver([
+            'api_key' => 'bad-key',
+            'sender_id' => 'TestSender',
+        ], $client);
+
+        $message = (new SmsMessage)->to('+2348134844186')->message('Test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send SMS via Termii');
+
+        $driver->send($message);
+    }
+}


### PR DESCRIPTION

Add four new SMS drivers targeting Africa/Nigeria:
- Sendchamp: bulk send, DND/non-DND/international routing, webhook with HMAC verification
- Termii: per-recipient send, generic/DND/WhatsApp channels
- Africa's Talking: comma-separated bulk recipients, sandbox mode, per-recipient status validation
- BulkSMS: basic auth, optional sender ID

Includes driver implementations, full test coverage, config registration, and updated README with a supported drivers reference table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new SMS providers: Sendchamp, Termii, Africa’s Talking, and BulkSMS, expanding delivery options.
  * Implemented provider-specific webhook handling, including optional signature verification for delivery status updates.
* **Documentation**
  * Expanded the README to list the supported drivers, added `.env` credential examples, and updated SMS driver configuration mappings.
* **Tests**
  * Added PHPUnit coverage for the new providers’ validation, sending behavior, and webhook handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->